### PR TITLE
Add support for Python 3.13 and 3.14

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -62,7 +62,7 @@ jobs:
       fail-fast: false
       matrix:
         os: [ubuntu-latest, windows-latest, macos-latest]
-        python-version: ["3.11", "3.12"]
+        python-version: ["3.11", "3.12", "3.13", "3.14"]
 
     steps:
       - uses: actions/checkout@v4

--- a/.github/workflows/unit-tests.yml
+++ b/.github/workflows/unit-tests.yml
@@ -13,7 +13,7 @@ jobs:
       fail-fast: false
       matrix:
         os: [ubuntu-latest, windows-latest, macos-latest]
-        python-version: ["3.11", "3.12"]
+        python-version: ["3.11", "3.12", "3.13", "3.14"]
 
     steps:
     - uses: actions/checkout@v4

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -11,7 +11,7 @@ maintainers = [
     {name = "Alexander März", email = "statmixedmlgit@gmail.com"}
 ]
 license = { file = "LICENSE" }
-requires-python = ">=3.11,<3.13"
+requires-python = ">=3.11,<3.15"
 keywords = [
     "Gradient Boosted Trees",
     "Hyper Models",
@@ -28,13 +28,15 @@ classifiers = [
     "Programming Language :: Python :: 3",
     "Programming Language :: Python :: 3.11",
     "Programming Language :: Python :: 3.12",
+    "Programming Language :: Python :: 3.13",
+    "Programming Language :: Python :: 3.14",
     "Operating System :: OS Independent",
 ]
 dependencies = [
     "lightgbm>=4.6",
     "numpy>=2.0",
     "pandas>=2.3",
-    "torch>=2,<2.10",
+    "torch>=2",
 ]
 
 [project.optional-dependencies]


### PR DESCRIPTION
## Summary
This PR extends Python version support to include Python 3.13 and 3.14, updating the project configuration and CI/CD workflows accordingly.

## Key Changes
- Updated `requires-python` constraint in `pyproject.toml` from `>=3.11,<3.13` to `>=3.11,<3.15`
- Added Python 3.13 and 3.14 to package classifiers in `pyproject.toml`
- Relaxed PyTorch dependency constraint from `torch>=2,<2.10` to `torch>=2` to support newer PyTorch versions with Python 3.13+
- Extended CI/CD test matrix in both `unit-tests.yml` and `release.yml` workflows to include Python 3.13 and 3.14

## Implementation Details
The PyTorch version constraint was relaxed to accommodate compatibility with Python 3.13 and 3.14, as newer Python versions may require newer PyTorch releases. All GitHub Actions workflows now test against the full range of supported Python versions (3.11, 3.12, 3.13, 3.14) across all major operating systems.

https://claude.ai/code/session_01XeAuFYAjkTK3Gniq9zbTrM