### PR TITLE
Relax shap upper bound for Python 3.13/3.14

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -42,7 +42,7 @@ dependencies = [
 [project.optional-dependencies]
 extras = [
     "matplotlib>=3.10",
-    "shap>=0.48,<0.51",
+    "shap>=0.48",
     "optuna>=4",
 ]
 


### PR DESCRIPTION
## Summary
Follow-up to #6 (Python 3.13/3.14 support). The `shap` extra was still capped at `<0.51`, which excludes every shap release that ships cp313/cp314 wheels — so `pip install "hypertrees-forecasting[extras]"` would fail on Python 3.13/3.14 (shap is compiled, not pure-Python).

## Change
- `pyproject.toml` (extras group): `shap>=0.48,<0.51` → `shap>=0.48`

## Why drop the cap entirely
This mirrors the `torch` upper-bound relaxation in #6. pip resolves the newest shap that fits each environment:
- **Py 3.11** → shap `0.51` (last line declaring `requires-python >=3.11`)
- **Py 3.12–3.14** → shap `0.52`

Both `0.51` and `0.52` provide cp313/cp314 wheels across Linux/Windows/macOS, so the `[extras]` install now works across the full 3.11–3.14 range. The `matplotlib` and `optuna` extras already had no upper cap.

https://claude.ai/code/session_01XeAuFYAjkTK3Gniq9zbTrM

---
_Generated by [Claude Code](https://claude.ai/code/session_01XeAuFYAjkTK3Gniq9zbTrM)_